### PR TITLE
KAN-55: Create Navigation Bar

### DIFF
--- a/src/ui/components/Hover/Hover.tsx
+++ b/src/ui/components/Hover/Hover.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 
 const Hover = ({
     icon: Icon,
-    label,
     size,
     // textBoxWidth = '100px',
     color = 'black',

--- a/src/ui/components/Hover/Hover.types.tsx
+++ b/src/ui/components/Hover/Hover.types.tsx
@@ -4,7 +4,6 @@ import { IconType } from "react-icons";
 
 export type HoverProps = {
     icon: IconType;
-    label: string;
     size: number;
     // textBoxWidth: string;
     color?: string;

--- a/src/ui/components/NavBar/Nav/Nav.tsx
+++ b/src/ui/components/NavBar/Nav/Nav.tsx
@@ -3,9 +3,9 @@ import { NavProps } from "./Nav.types";
 
 const Nav = ({children, routeTo, label, direction} : NavProps) => {
 
-    let linkTailWindClass = 'p-5 inline hover:bg-orange-500 float-left '
+    let linkTailWindClass = 'py-5 px-4 inline hover:bg-orange-500 float-left '
     if (direction === 'right') {
-        linkTailWindClass = 'p-5 inline hover:bg-orange-500 float-right'
+        linkTailWindClass = 'py-5 px-4 inline hover:bg-orange-500 float-right'
     };
 
     return (

--- a/src/ui/components/NavBar/Nav/Nav.tsx
+++ b/src/ui/components/NavBar/Nav/Nav.tsx
@@ -1,0 +1,20 @@
+import { Link } from "react-router-dom";
+import { NavProps } from "./Nav.types";
+
+const Nav = ({children, routeTo, label, direction} : NavProps) => {
+
+    let linkTailWindClass = 'p-5 inline hover:bg-orange-500 float-left '
+    if (direction === 'right') {
+        linkTailWindClass = 'p-5 inline hover:bg-orange-500 float-right'
+    };
+
+    return (
+        <Link className={linkTailWindClass} to={routeTo}>
+            {children ? children : <span className="h-16">{label}</span>
+            }
+        
+        </Link>
+    );
+};
+
+export default Nav;

--- a/src/ui/components/NavBar/Nav/Nav.types.tsx
+++ b/src/ui/components/NavBar/Nav/Nav.types.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from "react";
+
+export type NavProps = {
+    children?: ReactNode;
+    routeTo: string;
+    label?: string;
+    direction: 'left' | 'right';
+}

--- a/src/ui/components/NavBar/Nav/index.ts
+++ b/src/ui/components/NavBar/Nav/index.ts
@@ -1,0 +1,1 @@
+export { default as Nav } from './Nav'

--- a/src/ui/components/NavBar/NavBar.tsx
+++ b/src/ui/components/NavBar/NavBar.tsx
@@ -13,7 +13,6 @@ const NavBar = () => {
                 <Nav routeTo={routes.ROOT} direction='left'><FaBowlFood className='h-6 w-auto'/></Nav>
                 <Nav routeTo={routes.ROOT} label='Recipes' direction='left'/>
                 <Nav routeTo={routes.ROOT} label='Meal Plan' direction='left'/>
-                {/* When the user is signed in display user icon other wise display login and sign up */}
                 <Nav routeTo={routes.ROOT} direction='right'><FaRegUserCircle className='h-6 w-auto'/></Nav>
                 <Nav routeTo={routes.LOGIN} label='Login' direction='right'/>
                 <Nav routeTo={routes.SIGNUP} label='Sign Up' direction='right'/>

--- a/src/ui/components/NavBar/NavBar.tsx
+++ b/src/ui/components/NavBar/NavBar.tsx
@@ -1,0 +1,26 @@
+import routes from '@src/ui/routes/routes';
+
+import { FaRegUserCircle } from "react-icons/fa";
+import Nav from './Nav/Nav';
+import { FaBowlFood } from 'react-icons/fa6';
+
+const NavBar = () => {
+    // get UserContext
+    // const { user } = useContext(UserContext);
+    return (
+        <>
+            <ul className=' bg-orange-400 w-full h-16'>
+                <Nav routeTo={routes.ROOT} direction='left'><FaBowlFood className='h-6 w-auto'/></Nav>
+                <Nav routeTo={routes.ROOT} label='Recipes' direction='left'/>
+                <Nav routeTo={routes.ROOT} label='Meal Plan' direction='left'/>
+                {/* When the user is signed in display user icon other wise display login and sign up */}
+                <Nav routeTo={routes.ROOT} direction='right'><FaRegUserCircle className='h-6 w-auto'/></Nav>
+                <Nav routeTo={routes.LOGIN} label='Login' direction='right'/>
+                <Nav routeTo={routes.SIGNUP} label='Sign Up' direction='right'/>
+            </ul>
+        </>
+    )
+
+};
+
+export default NavBar;

--- a/src/ui/components/NavBar/index.ts
+++ b/src/ui/components/NavBar/index.ts
@@ -1,0 +1,1 @@
+export { default as NavBar } from './NavBar'

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -2,3 +2,4 @@ export { Loader } from './Loader';
 export { Button } from './Button';
 export { TextInput } from './TextInput';
 export { Hover } from './Hover';
+export { NavBar } from './NavBar';

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,3 +1,4 @@
 export { Loader } from './Loader';
 export { Button } from './Button';
 export { TextInput } from './TextInput';
+export { Hover } from './Hover';

--- a/src/ui/pages/Sample/Sample.tsx
+++ b/src/ui/pages/Sample/Sample.tsx
@@ -1,5 +1,4 @@
 import '@ui/index.css';
-import { TextInput } from '@ui/components'
 import { Link, useLocation } from 'react-router-dom';
 import routes from '@src/ui/routes/routes';
 // import useGetUser from '@src/ui/hooks/useGetUser';

--- a/src/ui/pages/Signup/Signup.tsx
+++ b/src/ui/pages/Signup/Signup.tsx
@@ -12,7 +12,6 @@ import {
     Link, 
     useNavigate,
     generatePath,
-    useLocation
 } from "react-router-dom";
 import { AuthContext } from '@src/ui/contexts/AuthContext';
 
@@ -136,7 +135,6 @@ const Signup = () => {
                     <div>
                         <Hover 
                             icon={FaCircleQuestion}
-                            label='hi'
                             size ={24}
                             // textBoxWidth='200px'
                             color='black'

--- a/src/ui/pages/Signup/Signup.tsx
+++ b/src/ui/pages/Signup/Signup.tsx
@@ -1,7 +1,6 @@
 // directory imports
 import '@ui/index.css'
-import { Button, Loader, TextInput} from '@ui/components';
-import { Hover } from '@src/ui/components/Hover';
+import { Button, Loader, TextInput, Hover} from '@ui/components';
 import routes from '@ui/routes/routes';
 import useSignup from '@ui/hooks/useSignup';
 


### PR DESCRIPTION
Created the Navigation Bar Component.
 
Logic to display and hide specific navs when logged in not yet implemented. pending user context ticket.
Mobile view not logged in:
<img width="467" alt="Screenshot 2024-08-11 at 3 52 45 PM" src="https://github.com/user-attachments/assets/8abde009-b6fd-41c7-8f8b-3c5851fa6edd">
Web view not logged in:
<img width="1461" alt="Screenshot 2024-08-11 at 3 54 21 PM" src="https://github.com/user-attachments/assets/69efd03c-3983-4df1-a3c4-674fc31c91a7">

Mobile view when logged in:
<img width="406" alt="Screenshot 2024-08-11 at 3 54 59 PM" src="https://github.com/user-attachments/assets/1522edd3-d806-4696-a6f2-03101f778632">
Web view when logged in:
<img width="1464" alt="Screenshot 2024-08-11 at 3 55 22 PM" src="https://github.com/user-attachments/assets/c4a5ba5a-e49d-430d-abbc-1fd1c3e5f38e">



