### PR TITLE
KAN-60: create recipe tiles component

### DIFF
--- a/src/ui/components/NavBar/NavBar.tsx
+++ b/src/ui/components/NavBar/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBar = () => {
                 <Nav routeTo={routes.ROOT} label='Meal Plan' direction='left'/>
                 <Nav routeTo={routes.ROOT} direction='right'><FaRegUserCircle className='h-6 w-auto'/></Nav>
                 <Nav routeTo={routes.LOGIN} label='Login' direction='right'/>
-                <Nav routeTo={routes.SIGNUP} label='Sign Up' direction='right'/>
+                {/* <Nav routeTo={routes.SIGNUP} label='Sign Up' direction='right'/> */}
             </ul>
         </>
     )

--- a/src/ui/components/NavBar/NavBar.tsx
+++ b/src/ui/components/NavBar/NavBar.tsx
@@ -15,7 +15,7 @@ const NavBar = () => {
                 <Nav routeTo={routes.ROOT} label='Meal Plan' direction='left'/>
                 <Nav routeTo={routes.ROOT} direction='right'><FaRegUserCircle className='h-6 w-auto'/></Nav>
                 <Nav routeTo={routes.LOGIN} label='Login' direction='right'/>
-                {/* <Nav routeTo={routes.SIGNUP} label='Sign Up' direction='right'/> */}
+                <Nav routeTo={routes.SIGNUP} label='Sign Up' direction='right'/>
             </ul>
         </>
     )

--- a/src/ui/components/Pill/Pill.tsx
+++ b/src/ui/components/Pill/Pill.tsx
@@ -1,0 +1,33 @@
+import { PillProp } from "./Pill.types";
+
+const Pill = ({ children, label, color } : PillProp) => {
+
+    let divColor = `bg-gray-400 border-gray-500`
+    
+
+    switch(color) {
+        case 'violet':
+            divColor = 'bg-violet-400 border-violet-500';
+            break;
+        case 'red':
+            divColor = "bg-red-400 border-red-500";
+            break;
+        case 'sky':
+            divColor = "bg-sky-300 border-sky-400";
+            break;
+        case 'orange':
+            divColor = "bg-orange-300 border-orange-400";
+            break;
+    }
+
+    const divClass = `h-fit flex justify-normal font-sans rounded-full p-0.5 m-0.5 border ${divColor}`
+
+    return (
+        <div className={divClass}>
+            {children}
+            <p className="text-xs px-1">{label}</p>
+        </div>
+    );
+};
+
+export default Pill;

--- a/src/ui/components/Pill/Pill.types.tsx
+++ b/src/ui/components/Pill/Pill.types.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from "react"
+
+
+export type PillProp = {
+    children?: ReactNode;
+    label?: string;
+    color: 'gray' | 'violet' | 'red' | 'sky' | 'orange';
+}

--- a/src/ui/components/Pill/index.ts
+++ b/src/ui/components/Pill/index.ts
@@ -1,0 +1,1 @@
+export { default as Pill } from './Pill';

--- a/src/ui/components/RecipeTile/RecipeTile.tsx
+++ b/src/ui/components/RecipeTile/RecipeTile.tsx
@@ -33,7 +33,7 @@ const RecipeTile = ({
         <div className=" bg-white w-64 h-64 rounded-lg border-2 border-solid border-black hover:border-red-500 hover:cursor-pointer" onClick={handleClick}>
             <div className="relative h-2/3 w-full rounded-t-l">
                 <div className='absolute h-full w-full overflow-hidden'>
-                    <img className="rounded-t-md w-auto" src={imageSrc} alt="recipe cover"/>
+                    <img className="rounded-t-md w-full h-full object-fill" src={imageSrc} alt="recipe cover"/>
                 </div>
                 <div className="absolute w-full h-full flex justify-end">
                     <Pill label={`✍:${author}`} color='orange'></Pill>

--- a/src/ui/components/RecipeTile/RecipeTile.tsx
+++ b/src/ui/components/RecipeTile/RecipeTile.tsx
@@ -1,0 +1,67 @@
+import { Pill } from '@ui/components'
+import routes from '@ui/routes/routes';
+import { RecipeTileProp } from './RecipeTile.types';
+
+
+import { MdOutlineTimer } from "react-icons/md";
+import { BsFillStarFill } from "react-icons/bs";
+import { 
+    useNavigate,
+    generatePath
+} from "react-router-dom";
+
+
+const RecipeTile = ({
+    title,
+    imageSrc='https://cdn.dribbble.com/users/1012566/screenshots/4187820/media/985748436085f06bb2bd63686ff491a5.jpg?resize=400x300&vertical=center',
+    author,
+    cookTime,
+    rating,
+    tags,
+    recipeId
+}: RecipeTileProp) => {
+
+    const navigate = useNavigate();
+
+    const handleClick = () => {
+        navigate(
+            generatePath(routes.RECIPE, { recipeId: recipeId })
+        );
+    };
+
+    return (
+        <div className=" bg-white w-64 h-64 rounded-lg border-2 border-solid border-black hover:border-red-500 hover:cursor-pointer" onClick={handleClick}>
+            <div className="relative h-2/3 w-full rounded-t-l">
+                <div className='absolute h-full w-full overflow-hidden'>
+                    <img className="rounded-t-md w-auto" src={imageSrc} alt="recipe cover"/>
+                </div>
+                <div className="absolute w-full h-full flex justify-end">
+                    <Pill label={`✍:${author}`} color='orange'></Pill>
+                </div>
+                <div className='absolute w-full h-full flex items-end p-1'>
+                    <Pill label={`${cookTime} min`} color='orange'><MdOutlineTimer/></Pill>
+                    <Pill label={rating.toString()} color='orange'><BsFillStarFill fill='yellow'/></Pill>
+                </div>
+            </div>
+        
+            <div className=" h-1/3 w-full bg-gray-300 rounded-b-md border-t-2 border-black">
+                <div className=" p-2 h-2/3 w-full text-sm overflow-hidden">
+                    {/* 2 lines 27 character limit per line. 27 character word limit */}
+                    <p className=" h-full w-full overflow-hidden">{title}</p>
+                </div>
+                
+                <div className=" h-1/3 flex justify-end overflow-hidden pb-1 px-1">
+                    {/* 2 - 3 tags displayed */}
+                    {tags.map(
+                        (tagName) => (
+                            <Pill label={tagName} color='sky'></Pill>
+                        )
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+
+export default RecipeTile;

--- a/src/ui/components/RecipeTile/RecipeTile.types.tsx
+++ b/src/ui/components/RecipeTile/RecipeTile.types.tsx
@@ -1,0 +1,9 @@
+export type RecipeTileProp = {
+    title: string;
+    imageSrc?: string;
+    author: string;
+    cookTime: number;
+    rating: number;
+    tags: string[];
+    recipeId: string;
+}

--- a/src/ui/components/RecipeTile/index.ts
+++ b/src/ui/components/RecipeTile/index.ts
@@ -1,0 +1,1 @@
+export { default as RecipeTile } from './RecipeTile';

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -3,3 +3,5 @@ export { Button } from './Button';
 export { TextInput } from './TextInput';
 export { Hover } from './Hover';
 export { NavBar } from './NavBar';
+export { RecipeTile } from './RecipeTile';
+export { Pill } from './Pill';

--- a/src/ui/pages/Sample/Sample.tsx
+++ b/src/ui/pages/Sample/Sample.tsx
@@ -1,18 +1,30 @@
 import '@ui/index.css';
-import { Link, useLocation } from 'react-router-dom';
-import routes from '@src/ui/routes/routes';
+
+import { NavBar, RecipeTile } from '@ui/components';
 // import useGetUser from '@src/ui/hooks/useGetUser';
 
 
 const Sample = () => {
 
     // const { isLoading: isLoadingData, error: isError, data} = useGetUser();
-    const location = useLocation();
+
     return (
         // <TextInput type="text" label="123" subLabel='AAAA' subLabelLink='#'/>
-<p className=" mt-10 text-center text-sm text-gray-500 ">
-                            Don't have an account? <Link to={routes.LOGIN} state={{prevPath: location.pathname}}className=" font-semibold leading-6 text-orange-600 hover:text-orange-500">Sign Up</Link>
-                    </p> 
+        <div className=' h-screen from-orange-300 to-yellow-200 bg-gradient-to-b'>
+            <NavBar/>
+            <div className='flex justify-center p-5'>
+                <RecipeTile 
+                    title="Title of Recipe" 
+                    author='Recipe Author Name' 
+                    cookTime={10} 
+                    rating={3.4} 
+                    tags={["spicy", "korean"]}
+                    recipeId="123"
+                />
+            </div>
+            
+        </div>
+        
     );
 };
 

--- a/src/ui/routes/index.tsx
+++ b/src/ui/routes/index.tsx
@@ -24,6 +24,13 @@ const Signup = lazy(() =>
     })),
 );
 
+// TODO: Update when view recipe page is created
+const Recipe = lazy(() => 
+    import('@ui/pages/Sample').then(({ Sample }) => ({
+        default: Sample,
+    }))
+);
+
 const PrivateRoutes = () => {
     const data = useGetAuth();
     const { setAuthenticated } = useContext(AuthContext);
@@ -42,6 +49,7 @@ const Routing = () =>{
             <Route path={routes.LOGIN} element={<Login/>}/>
             <Route path={routes.SAMPLE} element={<Sample/>}/>
             <Route path={routes.SIGNUP} element={<Signup/>}/>
+            <Route path={routes.RECIPE} element={<Recipe/>}/>
             <Route element={<PrivateRoutes/>}>
                 <Route path={routes.ROOT} element={<Sample/>}/>
             </Route>

--- a/src/ui/routes/routes.ts
+++ b/src/ui/routes/routes.ts
@@ -2,6 +2,7 @@ enum Routes {
     ROOT = '/',
     LOGIN = '/login',
     SIGNUP = '/signup',
+    RECIPE = '/recipe/:recipeId',
     SAMPLE = '/sample'
 }
 


### PR DESCRIPTION

<img width="836" alt="Screenshot 2024-08-18 at 5 49 17 PM" src="https://github.com/user-attachments/assets/f7b601a4-1e8b-40dc-b090-b4d5b7acae58">


Created the recipe tiles component.

each tile takes in the argument
`title`, `author`, `image link`, `array of tag strings`,`recipeId string`, `cook time`, and `rating`

tags are dynamically created it is recommended to only have 3 max.

on click it should link to the recipe page (currently it goes to the link but the sample page is displayed for now).

Image displayed is the default image, 404 missing image.